### PR TITLE
Add StringToBins() and NewFromBins() functions

### DIFF
--- a/circonusllhist.go
+++ b/circonusllhist.go
@@ -11,6 +11,8 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"strconv"
+	"strings"
 	"sync"
 )
 
@@ -240,6 +242,16 @@ func NewNoLocks() *Histogram {
 		used:     0,
 		bvs:      make([]Bin, DEFAULT_HIST_SIZE),
 		useLocks: false,
+	}
+}
+
+// NewFromBins returns a Histogram created from a bins struct slice
+func NewFromBins(bins []Bin, locks bool) *Histogram {
+	return &Histogram{
+		allocd:   uint16(len(bins) + 10), // pad it with 10
+		used:     uint16(len(bins)),
+		bvs:      bins,
+		useLocks: locks,
 	}
 }
 
@@ -629,4 +641,38 @@ func (h *Histogram) DecStrings() []string {
 		out[i] = buffer.String()
 	}
 	return out
+}
+
+// takes the output of DecStrings and deserializes it into a Bin struct slice
+func StringsToBin(strs []string) ([]Bin, error) {
+
+	bins := make([]Bin, len(strs))
+	for i, str := range strs {
+
+		// H[0.0e+00]=1
+
+		// H[0.0e+00]= <1>
+		countString := strings.Split(str, "=")[1]
+		countInt, err := strconv.ParseInt(countString, 10, 64)
+		if err != nil {
+			return nil, err
+		}
+
+		// H[ <0.0> e+00]=1
+		valString := strings.Split(strings.Split(strings.Split(str, "=")[0], "e")[0], "[")[1]
+		valInt, err := strconv.ParseFloat(valString, 64)
+		if err != nil {
+			return nil, err
+		}
+
+		// H[0.0e <+00> ]=1
+		expString := strings.Split(strings.Split(strings.Split(str, "=")[0], "e")[1], "]")[0]
+		expInt, err := strconv.ParseInt(expString, 10, 8)
+		if err != nil {
+			return nil, err
+		}
+		bins[i] = *NewBinRaw(int8(valInt*10), int8(expInt), uint64(countInt))
+	}
+
+	return bins, nil
 }

--- a/circonusllhist.go
+++ b/circonusllhist.go
@@ -245,8 +245,19 @@ func NewNoLocks() *Histogram {
 	}
 }
 
+// NewFromStrings returns a Histogram created from DecStrings strings
+func NewFromStrings(strs []string, locks bool) (*Histogram, error) {
+
+	bin, err := stringsToBin(strs)
+	if err != nil {
+		return nil, err
+	}
+
+	return newFromBins(bin, locks), nil
+}
+
 // NewFromBins returns a Histogram created from a bins struct slice
-func NewFromBins(bins []Bin, locks bool) *Histogram {
+func newFromBins(bins []Bin, locks bool) *Histogram {
 	return &Histogram{
 		allocd:   uint16(len(bins) + 10), // pad it with 10
 		used:     uint16(len(bins)),
@@ -644,7 +655,7 @@ func (h *Histogram) DecStrings() []string {
 }
 
 // takes the output of DecStrings and deserializes it into a Bin struct slice
-func StringsToBin(strs []string) ([]Bin, error) {
+func stringsToBin(strs []string) ([]Bin, error) {
 
 	bins := make([]Bin, len(strs))
 	for i, str := range strs {

--- a/circonusllhist_test.go
+++ b/circonusllhist_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	hist "github.com/redhotpenguin/circonusllhist"
+	hist "github.com/circonus-labs/circonusllhist"
 )
 
 func helpTestBin(t *testing.T, v float64, val, exp int8) {

--- a/circonusllhist_test.go
+++ b/circonusllhist_test.go
@@ -84,8 +84,47 @@ func TestDecStrings(t *testing.T) {
 		"H[4.3e-01]=1"}
 	for i, str := range expect {
 		if str != out[i] {
-			t.Errorf(" DecString '%v' != '%v'", out[i], str)
+			t.Errorf("DecString '%v' != '%v'", out[i], str)
 		}
+	}
+}
+
+func TestStringsToBin(t *testing.T) {
+
+	strings := []string{"H[0.0e+00]=1", "H[1.2e-01]=2", "H[1.3e-01]=1",
+		"H[2.2e-01]=1", "H[3.2e-01]=1", "H[4.1e-01]=2", "H[4.3e-01]=1",
+		"H[9.9e+127]=4294967296", "H[-0.1e-128]=4294967296"}
+
+	bins, err := hist.StringsToBin(strings)
+
+	if err != nil {
+		t.Errorf("Error in StringsToBin '%v'", err)
+	}
+
+	testbins := []hist.Bin{
+		*hist.NewBinRaw(0, 0, 1), *hist.NewBinRaw(12, -1, 2),
+		*hist.NewBinRaw(13, -1, 1), *hist.NewBinRaw(22, -1, 1),
+		*hist.NewBinRaw(32, -1, 1), *hist.NewBinRaw(41, -1, 2),
+		*hist.NewBinRaw(43, -1, 1), *hist.NewBinRaw(99, 127, 4294967296),
+		*hist.NewBinRaw(-1, -128, 4294967296)}
+
+	for i, bin := range bins {
+		if bin.Val() != testbins[i].Val() {
+			t.Errorf("bin val '%v' does not match test val '%v'", bin.Val(), testbins[i].Val())
+		}
+		if bin.Exp() != testbins[i].Exp() {
+			t.Errorf("bin exp '%v' does not match test exp '%v'", bin.Exp(), testbins[i].Exp())
+		}
+		if bin.Count() != testbins[i].Count() {
+			t.Errorf("bin count '%v' does not match test count '%v'", bin.Count(), testbins[i].Count())
+		}
+	}
+
+	// test that we can create a histogram from multiples of bins
+	h := hist.NewFromBins(append(bins, bins...), false)
+	var min = h.Min()
+	if min != 0 {
+		t.Errorf("incorrect min value '%v'", min)
 	}
 }
 
@@ -181,7 +220,7 @@ func TestRang(t *testing.T) {
 	src := rand.NewSource(time.Now().UnixNano())
 	rnd := rand.New(src)
 	for i := 0; i < 1000000; i++ {
-		h1.RecordValue(rnd.Float64()*10)
+		h1.RecordValue(rnd.Float64() * 10)
 	}
 }
 func TestEquals(t *testing.T) {


### PR DESCRIPTION
Looking for feedback on these changes to deserialize the DecStrings() output back into a []Bin. The use case is to take the output of DecStrings(), send it over the wire, and combine those bins with others into an aggregate histogram.

The deserialization code is a bit crude; if it looks like it was written by a Perl programmer, there's a reason for that. I used split rather than slicing the string as bytes as the implementation seemed to be easier to read, though the byte slice approach would have the advantage of one less dependency (and probably a bit faster).

Please let me know how this looks; pretty sure it can be improved on.