### PR TITLE
Use sync.RWMutex instead of sync.Mutex

### DIFF
--- a/circonusllhist.go
+++ b/circonusllhist.go
@@ -235,7 +235,7 @@ type Histogram struct {
 
 	lookup [256][]uint16
 
-	mutex    sync.Mutex
+	mutex    sync.RWMutex
 	useLocks bool
 }
 
@@ -481,8 +481,8 @@ func (h *Histogram) RecordValues(v float64, n int64) error {
 // Approximate mean
 func (h *Histogram) ApproxMean() float64 {
 	if h.useLocks {
-		h.mutex.Lock()
-		defer h.mutex.Unlock()
+		h.mutex.RLock()
+		defer h.mutex.RUnlock()
 	}
 	divisor := 0.0
 	sum := 0.0
@@ -501,8 +501,8 @@ func (h *Histogram) ApproxMean() float64 {
 // Approximate sum
 func (h *Histogram) ApproxSum() float64 {
 	if h.useLocks {
-		h.mutex.Lock()
-		defer h.mutex.Unlock()
+		h.mutex.RLock()
+		defer h.mutex.RUnlock()
 	}
 	sum := 0.0
 	for i := uint16(0); i < h.used; i++ {
@@ -515,8 +515,8 @@ func (h *Histogram) ApproxSum() float64 {
 
 func (h *Histogram) ApproxQuantile(q_in []float64) ([]float64, error) {
 	if h.useLocks {
-		h.mutex.Lock()
-		defer h.mutex.Unlock()
+		h.mutex.RLock()
+		defer h.mutex.RUnlock()
 	}
 	q_out := make([]float64, len(q_in))
 	i_q, i_b := 0, uint16(0)
@@ -583,8 +583,8 @@ func (h *Histogram) ApproxQuantile(q_in []float64) ([]float64, error) {
 // ValueAtQuantile returns the recorded value at the given quantile (0..1).
 func (h *Histogram) ValueAtQuantile(q float64) float64 {
 	if h.useLocks {
-		h.mutex.Lock()
-		defer h.mutex.Unlock()
+		h.mutex.RLock()
+		defer h.mutex.RUnlock()
 	}
 	q_in := make([]float64, 1)
 	q_in[0] = q
@@ -605,12 +605,12 @@ func (h *Histogram) SignificantFigures() int64 {
 // Equals returns true if the two Histograms are equivalent, false if not.
 func (h *Histogram) Equals(other *Histogram) bool {
 	if h.useLocks {
-		h.mutex.Lock()
-		defer h.mutex.Unlock()
+		h.mutex.RLock()
+		defer h.mutex.RUnlock()
 	}
 	if other.useLocks {
-		other.mutex.Lock()
-		defer other.mutex.Unlock()
+		other.mutex.RLock()
+		defer other.mutex.RUnlock()
 	}
 	switch {
 	case

--- a/circonusllhist_test.go
+++ b/circonusllhist_test.go
@@ -246,3 +246,36 @@ func TestEquals(t *testing.T) {
 		t.Error("Expected Histograms to be equivalent")
 	}
 }
+
+func TestMinMaxMean(t *testing.T) {
+	const (
+		minVal = 0
+		maxVal = 1000000
+	)
+
+	h := hist.New()
+	for i := minVal; i < maxVal; i++ {
+		if err := h.RecordValue(float64(i)); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if h.Min() > minVal {
+		t.Error("incorrect min value")
+	}
+
+	if h.Max() < maxVal {
+		t.Error("incorrect max value")
+	}
+
+	round := func(val float64) int {
+		if val < 0 {
+			return int(val - 0.5)
+		}
+		return int(val + 0.5)
+	}
+
+	if round(h.Mean()) != round(maxVal/2) {
+		t.Errorf("incorrect mean value")
+	}
+}

--- a/circonusllhist_test.go
+++ b/circonusllhist_test.go
@@ -15,6 +15,7 @@ func helpTestBin(t *testing.T, v float64, val, exp int8) {
 		t.Errorf("%v -> [%v,%v] expected, but got [%v,%v]", v, val, exp, b.Val(), b.Exp())
 	}
 }
+
 func fuzzy_equals(expected, actual float64) bool {
 	delta := math.Abs(expected / 100000.0)
 	if actual >= expected-delta && actual <= expected+delta {
@@ -22,6 +23,7 @@ func fuzzy_equals(expected, actual float64) bool {
 	}
 	return false
 }
+
 func TestBins(t *testing.T) {
 	helpTestBin(t, 0.0, 0, 0)
 	helpTestBin(t, 9.9999e-129, 0, 0)
@@ -57,6 +59,7 @@ func helpTestVB(t *testing.T, v, b, w float64) {
 		t.Errorf("%v -> [%v] != [%v]\n", v, interval, w)
 	}
 }
+
 func TestBinSizes(t *testing.T) {
 	helpTestVB(t, 43.3, 43.0, 1.0)
 	helpTestVB(t, 99.9, 99.0, 1.0)
@@ -142,6 +145,7 @@ func helpQTest(t *testing.T, vals, qin, qexpect []float64) {
 		}
 	}
 }
+
 func TestQuantiles(t *testing.T) {
 	helpQTest(t, []float64{1}, []float64{0, 0.25, 0.5, 1}, []float64{1, 1.025, 1.05, 1.1})
 	helpQTest(t, s1, []float64{0, 0.95, 0.99, 1.0}, []float64{0, 0.4355, 0.4391, 0.44})
@@ -215,6 +219,7 @@ func TestRang(t *testing.T) {
 		h1.RecordValue(rnd.Float64() * 10)
 	}
 }
+
 func TestEquals(t *testing.T) {
 	h1 := hist.New()
 	for i := 0; i < 1000000; i++ {

--- a/circonusllhist_test.go
+++ b/circonusllhist_test.go
@@ -96,14 +96,14 @@ func TestNewFromStrings(t *testing.T) {
 	// hist of single set of strings
 	singleHist, err := hist.NewFromStrings(strings, false)
 	if err != nil {
-		t.Error("error creating hist from strings '%v'", err)
+		t.Errorf("error creating hist from strings '%v'", err)
 	}
 
 	// hist of multiple sets of strings
 	strings = append(strings, strings...)
 	doubleHist, err := hist.NewFromStrings(strings, false)
 	if err != nil {
-		t.Error("error creating hist from strings '%v'", err)
+		t.Errorf("error creating hist from strings '%v'", err)
 	}
 
 	// sanity check the sums are doubled


### PR DESCRIPTION
Use a read-write mutex instead of an exclusive mutex in order to prevent problems with recursive lock acquisition, which results in a deadlock.  See the individual commits for additional detail.