### PR TITLE
allow for serialization of the histogram into raw and base64 formats

### DIFF
--- a/circonusllhist.go
+++ b/circonusllhist.go
@@ -329,7 +329,7 @@ func readBin(in io.Reader) (out bin, err error) {
 		return
 	}
 	if bvl > uint8(BVL8) {
-		return
+		return out, errors.New("encoding error: bvl value is greater than max allowable")
 	}
 
 	bcount := make([]byte, 8)
@@ -362,10 +362,10 @@ func Deserialize(in io.Reader) (h *Histogram, err error) {
 
 	for ii := int16(0); ii < nbin; ii++ {
 		bb, err := readBin(in)
-		h.insertBin(&bb, int64(bb.count))
 		if err != nil {
 			return h, err
 		}
+		h.insertBin(&bb, int64(bb.count))
 	}
 	return h, nil
 }

--- a/circonusllhist_test.go
+++ b/circonusllhist_test.go
@@ -17,7 +17,9 @@ func TestSerialize(t *testing.T) {
 	}
 
 	buf := bytes.NewBuffer([]byte{})
-	h.Serialize(buf)
+	if err := h.Serialize(buf); err != nil {
+		t.Error(err)
+	}
 
 	h2, err := Deserialize(buf)
 	if err != nil {

--- a/internal_test.go
+++ b/internal_test.go
@@ -17,9 +17,9 @@ func TestSerialize(t *testing.T) {
 	}
 
 	buf := bytes.NewBuffer([]byte{})
-	h.SerializeRaw(buf)
+	h.Serialize(buf)
 
-	h2, err := DeserializeRaw(buf)
+	h2, err := Deserialize(buf)
 	if err != nil {
 		t.Error(h2, err)
 	}

--- a/internal_test.go
+++ b/internal_test.go
@@ -1,9 +1,34 @@
 package circonusllhist
 
 import (
+	"bytes"
 	"math"
 	"testing"
 )
+
+func TestSerialize(t *testing.T) {
+	h, err := NewFromStrings([]string{
+		"H[0.0e+00]=1",
+		"H[1.0e+01]=1",
+		"H[2.0e+02]=1",
+	}, false)
+	if err != nil {
+		t.Error("could not read from strings for test")
+	}
+
+	buf := bytes.NewBuffer([]byte{})
+	h.SerializeRaw(buf)
+
+	h2, err := DeserializeRaw(buf)
+	if err != nil {
+		t.Error(h2, err)
+	}
+	if !h.Equals(h2) {
+		t.Log(h.DecStrings())
+		t.Log(h2.DecStrings())
+		t.Error("histograms do not match")
+	}
+}
 
 func helpTestBin(t *testing.T, v float64, val, exp int8) {
 	b := newBinFromFloat64(v)


### PR DESCRIPTION
This will convert the histogram into a a representation consumable by the write histogram api.  New public methods added are SerializeRaw and SerializeB64.