### PR TITLE
Implement copy without reset function

### DIFF
--- a/api_test.go
+++ b/api_test.go
@@ -240,3 +240,18 @@ func TestCopy(t *testing.T) {
 		t.Errorf("expected copy: %v to equal original: %v", h2, h1)
 	}
 }
+
+func TestFullReset(t *testing.T) {
+	h1 := hist.New()
+	for i := 0; i < 1000000; i++ {
+		if err := h1.RecordValue(float64(i)); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	h1.Reset()
+	h2 := hist.New()
+	if !h2.Equals(h1) {
+		t.Errorf("expected reset value: %v to equal new value: %v", h1, h2)
+	}
+}

--- a/api_test.go
+++ b/api_test.go
@@ -226,3 +226,17 @@ func TestMinMaxMean(t *testing.T) {
 		t.Errorf("incorrect mean value")
 	}
 }
+
+func TestCopy(t *testing.T) {
+	h1 := hist.New()
+	for i := 0; i < 1000000; i++ {
+		if err := h1.RecordValue(float64(i)); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	h2 := h1.Copy()
+	if !h2.Equals(h1) {
+		t.Errorf("expected copy: %v to equal original: %v", h2, h1)
+	}
+}

--- a/circonusllhist.go
+++ b/circonusllhist.go
@@ -817,6 +817,27 @@ func (h *Histogram) CopyAndReset() *Histogram {
 	}
 	return newhist
 }
+
+// Copy creates and returns an exact copy of a histogram without
+// resetting the contents of the original.
+func (h *Histogram) Copy() *Histogram {
+	if h.useLocks {
+		h.mutex.Lock()
+		defer h.mutex.Unlock()
+	}
+
+	bvs := []bin{}
+	for _, v := range h.bvs {
+		bvs = append(bvs, v)
+	}
+
+	return &Histogram{
+		allocd: h.allocd,
+		used:   h.used,
+		bvs:    bvs,
+	}
+}
+
 func (h *Histogram) DecStrings() []string {
 	if h.useLocks {
 		h.mutex.Lock()

--- a/circonusllhist.go
+++ b/circonusllhist.go
@@ -831,10 +831,18 @@ func (h *Histogram) Copy() *Histogram {
 		bvs = append(bvs, v)
 	}
 
+	lookup := [256][]uint16{}
+	for i, u := range h.lookup {
+		for _, v := range u {
+			lookup[i] = append(lookup[i], v)
+		}
+	}
+
 	return &Histogram{
 		allocd: h.allocd,
 		used:   h.used,
 		bvs:    bvs,
+		lookup: lookup,
 	}
 }
 


### PR DESCRIPTION
### This PR ([#13](https://github.com/circonus-labs/circonusllhist/pull/13)):
- Adds a Copy() method to the Histogram type.  This method is based on the functionality of CopyAndReset(), but it does not reset the data in the original histogram.
  - The new Copy() function copies the useLocks value of the original histogram, and uses the New() function to ensure correct handling of defaults.
- Implements a unit test for the Copy() method.
- Adds a FullReset() method to the Histogram type.  This method will reset all histogram data values back to default values without altering its useLocks setting.
- Modifies the CopyAndReset() method of the Histogram type to call the Copy() method, then the Reset() method, and return the result of the Copy() method.