### PR TITLE
swap copy arguments

### DIFF
--- a/circonusllhist.go
+++ b/circonusllhist.go
@@ -912,7 +912,7 @@ func (h *Histogram) Copy() *Histogram {
 	newhist.useLocks = h.useLocks
 
 	newhist.bvs = make([]bin, len(h.bvs))
-	copy(h.bvs, newhist.bvs)
+	copy(newhist.bvs, h.bvs)
 
 	newhist.useLookup = h.useLookup
 	if h.useLookup {


### PR DESCRIPTION
Swap copy arguments such that `newhist` is the destination and `h` is the source